### PR TITLE
Fix/always notify of initial state

### DIFF
--- a/src/listenable/Listenable.js
+++ b/src/listenable/Listenable.js
@@ -229,7 +229,7 @@ class Listenable {
 
         const lastValue = this[propName];
 
-        if (lastValue === value) {
+        if (propName in this && lastValue === value) {
             if (typeof value === 'object' && value !== null) {
                 this._handleError(
                     new Error(`Tried to set an object which was already present. propName: "${propName}", value: ${JSON.stringify(value)}`),

--- a/src/reactito/index.js
+++ b/src/reactito/index.js
@@ -3,6 +3,8 @@ import PockitoListenable from '../listenable/Listenable';
 export const StateInjector = (component) => (value, lastValue, propName) => component.setState({ [propName]: value });
 
 export function listenWhileMounted(component, props) {
+    component.state = component.state || {};
+
     const originalComponentWillUnmount = component.componentWillUnmount;
     const unlisten = this.addListener(StateInjector(component), props);
 
@@ -16,6 +18,8 @@ export function listenWhileMounted(component, props) {
 }
 
 export function listenWhileMountedRemap(component, propsObject) {
+    component.state = component.state || {};
+
     const propsToListenTo = Object.keys(propsObject);
     const mapToNewPropName = (storePropName) => propsObject[storePropName];
 

--- a/test/__tests__/ReactitoListenableTest.js
+++ b/test/__tests__/ReactitoListenableTest.js
@@ -66,4 +66,64 @@ describe('Reactito.Listenable:', () => {
         expect(flop).toEqual('bar');
         expect(unmounted).toEqual(true);
     });
+
+    it('removes the need for initial state in React.Components (when using listenWhileMounted)', () => {
+        const Store = new ReactitoListenable();
+
+        const comp = {
+            setState: function(obj) {
+                comp.state = obj
+            }
+        };
+
+        Store.listenWhileMounted(comp);
+
+        expect(typeof comp.state).toEqual('object');
+    });
+    it('but does not overwrite React.Components initial state (when using listenWhileMounted)', () => {
+        const Store = new ReactitoListenable();
+
+        const comp = {
+            state: {
+                foo: 'bar'
+            },
+            setState: function(obj) {
+                comp.state = obj
+            }
+        };
+
+        Store.listenWhileMounted(comp);
+
+        expect(comp.state.foo).toEqual('bar');
+    });
+
+    it('removes the need for initial state in React.Components (when using listenWhileMountedRemap)', () => {
+        const Store = new ReactitoListenable();
+
+        const comp = {
+            setState: function(obj) {
+                comp.state = obj
+            }
+        };
+
+        Store.listenWhileMountedRemap(comp, {empty: 'empty'});
+
+        expect(typeof comp.state).toEqual('object');
+    });
+    it('but does not overwrite React.Components initial state (when using listenWhileMountedRemap)', () => {
+        const Store = new ReactitoListenable();
+
+        const comp = {
+            state: {
+                foo: 'bar'
+            },
+            setState: function(obj) {
+                comp.state = obj
+            }
+        };
+
+        Store.listenWhileMountedRemap(comp, {empty: 'empty'});
+
+        expect(comp.state.foo).toEqual('bar');
+    });
 });

--- a/test/__tests__/SimpleListenableTest.js
+++ b/test/__tests__/SimpleListenableTest.js
@@ -126,4 +126,26 @@ describe('Listenable (with no arguments)', () => {
 
         evaluate(['foo']);
     });
+
+    it('notifies listeners of initialState, even undefined values', () => {
+        setup();
+
+        const Store = new Listenable({
+            initialState: {
+                empty: void 0
+            }
+        });
+
+        let wasNotified = false;
+
+        Store.addListener((value, last, propName) => {
+            wasNotified = true;
+
+            expect(value).toEqual(void 0);
+            expect(last).toEqual(void 0);
+            expect(propName).toEqual('empty');
+        });
+
+        expect(wasNotified).toEqual(true);
+    })
 });


### PR DESCRIPTION
Resolve issue #15

You can now be certain that calling `listenWhileMounted` or `listenWhileMountedRemap` creates an initial state (if none exists already) on the React Component, so setting state as a preemptive measure is no longer necessary, regardless of store state.
